### PR TITLE
angular-typesafe-reactive-forms-helper package should not be dependency of any integration tests.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -469,6 +469,23 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -508,6 +525,28 @@
       "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
       "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "13.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.5.tgz",
+      "integrity": "sha512-hkzMMD3xu6BrJpGVLeQ3htQQNAcOrJjX7WFmtK8zWQpz2UJf13LCFF2ALA7c9OVdvc2vQJeDdjfR35M0sBCxvw==",
+      "dev": true
+    },
+    "@types/shelljs": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.7.tgz",
+      "integrity": "sha512-Mg2qGjLIJIieeJ1/NjswAOY9qXDShLeh6JwpD1NZsvUvI0hxdUCNDpnBXv9YQeugKi2EHU+BqkbUE4jpY4GKmQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -2443,6 +2482,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -4003,6 +4048,15 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -4276,6 +4330,17 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "integration-tests:test-ci:ng8": "cd ./intergationTests/ng8/test-package-with-ng8 && cross-env CI=true ng test --watch=false",
     "integration-tests:install:ng9": "cd ./intergationTests/ng9/test-package-with-ng9 && npm i && npm i ../../angular-typesafe-reactive-forms-helper.tgz",
     "integration-tests:test-ci:ng9": "cd ./intergationTests/ng9/test-package-with-ng9 && cross-env CI=true ng test --watch=false"
-
   },
   "repository": {
     "type": "git",
@@ -53,12 +52,14 @@
     "@angular/forms": "^9.0.6",
     "@angular/platform-browser": "^9.0.6",
     "@types/jest": "^24.0.18",
+    "@types/shelljs": "^0.8.7",
     "cross-env": "^7.0.2",
     "jest": "^24.9.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
     "rimraf": "^3.0.0",
     "rxjs": "^6.5.3",
+    "shelljs": "^0.8.3",
     "ts-jest": "^24.0.2",
     "tslib": "^1.10.0",
     "tslint": "^5.19.0",

--- a/src/__tests__/packageLockFile.spec.ts
+++ b/src/__tests__/packageLockFile.spec.ts
@@ -20,12 +20,10 @@ describe('intergationTests Package-lock.json', () => {
         const dependencyDetectedList = lockFiles.map(lockFile => {
           const hasDependencyOnLock = exec(`cat ${lockFile} | grep angular-typesafe-reactive-forms`).stdout && true || false;
           const hasDependency = exec(`cat ${lockFile.replace('-lock.json','.json')} | grep angular-typesafe-reactive-forms`).stdout && true || false;
-          if (hasDependency || hasDependencyOnLock){
+          if (hasDependency || hasDependencyOnLock) {
             return `- Please remove 'angular-typesafe-reactive-forms' dependency from ${lockFile.replace('-lock.json','.json')} and ${lockFile}.`
           }
-
           return null;
-
         })
         .filter(found => found);
 

--- a/src/__tests__/packageLockFile.spec.ts
+++ b/src/__tests__/packageLockFile.spec.ts
@@ -1,0 +1,34 @@
+import {exec} from 'shelljs';
+
+/*
+  This will break the CI build pipeline.
+
+  In order to test the package with all the different versions of angular, 
+  the pipeline will pack a local angular-typesafe-reactive-forms package.
+  That new package is then installed locally on the build server to each Angular version.
+  If there is an existing angular-typesafe-reactive-forms in the package.json, the integrity calculation will be different, which will break the build on 'npm install' command.
+
+  This is my hack to get around it...at least for now :)
+*/
+describe('intergationTests Package-lock.json', () => {
+      test('Should not have the angular-typesafe-reactive-forms package dependency installed', () => {
+        const lockFiles = exec(`ls ***/**/*/package-lock.json`)
+        .stdout
+        .split('\n')
+        .filter(file => file);
+  
+        const dependencyDetectedList = lockFiles.map(lockFile => {
+          const hasDependencyOnLock = exec(`cat ${lockFile} | grep angular-typesafe-reactive-forms`).stdout && true || false;
+          const hasDependency = exec(`cat ${lockFile.replace('-lock.json','.json')} | grep angular-typesafe-reactive-forms`).stdout && true || false;
+          if (hasDependency || hasDependencyOnLock){
+            return `- Please remove 'angular-typesafe-reactive-forms' dependency from ${lockFile.replace('-lock.json','.json')} and ${lockFile}.`
+          }
+
+          return null;
+
+        })
+        .filter(found => found);
+
+        expect(dependencyDetectedList.join('\n')).toBe('');
+  });
+});


### PR DESCRIPTION
Add unit tests to make sure the angular-typesafe-reactive-forms-helper package is not a dependency on all integration tests.
It will be installed as part of the build process.