### PR TITLE
Fix issue 113

### DIFF
--- a/src/getPropertyName.ts
+++ b/src/getPropertyName.ts
@@ -2,7 +2,7 @@ export const getPropertyName = (propertyFunction: string) => {
   let properties: string[] = [];
 
   if (propertyFunction) {
-    if (propertyFunction.toString().indexOf('=>') !== -1) {
+    if (propertyFunction.toString().includes('=>')) {
       // propertyFunction.toString() sample value:
       // x => x.hero.address.postcode
       // we need the 'hero.address.postcode'
@@ -19,9 +19,9 @@ export const getPropertyName = (propertyFunction: string) => {
       // we need the 'hero.address.postcode'
       // for gr.get('hero.address.postcode') function
 
-      const step1 = propertyFunction && propertyFunction.match(/(return [;.a-zA-Z0-9 ]+)/gi);
-      const step2 = step1 && step1[0].match(/(?![. ])([a-z0-9_]+)(?=[};.])/gi);
-      properties = (step2 && step2.splice(1)) || [];
+      const step1 = propertyFunction.match(/return\s+([.a-zA-Z0-9]+)/i); // get the return part of the propertyFunction eg: return x.hero.address.postcode;
+	    const step2 = step1 && step1[1].match(/([a-z0-9_]+)/gi); // split the step1[1] text to return an array eg: ['x','hero','address','postcode']
+	    properties = (step2 && step2.splice(1)) || [];
     }
   }
 

--- a/tests/__tests__/getProprtyName.spec.ts
+++ b/tests/__tests__/getProprtyName.spec.ts
@@ -2,19 +2,22 @@ import { getPropertyName } from '../../src/getPropertyName';
 
 const expectedProperty = 'hero.address.postcode';
 
-describe(`getPropertyName should return '${expectedProperty}' when`, () => {
-  test('function(x) { return x.hero.address.postcode;}', () => {
-    const testScenario = 'function(x) { return x.hero.address.postcode;}';
-    expect(getPropertyName(testScenario)).toBe(expectedProperty);
-  });
+const testScenarios = [
+  'function(x) { return x.hero.address.postcode;}',
+  'function(t){return t.hero.address.postcode}', 
+  'function(t){return t.hero.address.postcode} ', 
+  'function(t){return t.hero.address.postcode }', 
+  'function(t){return t.hero.address.postcode ;}',
+  'x => x.hero.address.postcode',
+  'function(x){cov_2imlqdpfhj.f[46]++;cov_2imlqdpfhj.s[149]++;return x.hero.address.postcode;}',
+];
 
-  test('x => x.hero.address.postcode', () => {
-    const testScenario = 'x => x.hero.address.postcode';
-    expect(getPropertyName(testScenario)).toBe(expectedProperty);
-  });
-
-  test('function(x){cov_2imlqdpfhj.f[46]++;cov_2imlqdpfhj.s[149]++;return x.hero.address.postcode;}', () => {
-    const testScenario = 'function(x){cov_2imlqdpfhj.f[46]++;cov_2imlqdpfhj.s[149]++;return x.hero.address.postcode;}';
-    expect(getPropertyName(testScenario)).toBe(expectedProperty);
-  });
+describe.only(`getPropertyName should return '${expectedProperty}' when`, () => {
+  test.each(testScenarios)(
+    "%p",
+    (testScenario) => {
+      expect(getPropertyName(testScenario)).toBe(expectedProperty);
+    }
+  );
 });
+


### PR DESCRIPTION
Main problem:
The regex parsing fails due to the missing semicolon when production build compiles to ES5. 

Fix issue [113](https://github.com/rpbeukes/angular-typesafe-reactive-forms-helper/issues/113).