### PR TITLE
Revert "Bump puppeteer from 11.0.0 to 12.0.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3578,9 +3578,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.937139",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.937139.tgz",
-      "integrity": "sha512-daj+rzR3QSxsPRy5vjjthn58axO8c11j58uY0lG5vvlJk/EiOdCWOptGdkXDjtuRHr78emKq0udHCXM4trhoDQ==",
+      "version": "0.0.901419",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
+      "integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==",
       "dev": true
     },
     "diff": {
@@ -10217,13 +10217,13 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-12.0.1.tgz",
-      "integrity": "sha512-YQ3GRiyZW0ddxTW+iiQcv2/8TT5c3+FcRUCg7F8q2gHqxd5akZN400VRXr9cHQKLWGukmJLDiE72MrcLK9tFHQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-11.0.0.tgz",
+      "integrity": "sha512-6rPFqN1ABjn4shgOICGDBITTRV09EjXVqhDERBDKwCLz0UyBxeeBH6Ay0vQUJ84VACmlxwzOIzVEJXThcF3aNg==",
       "dev": true,
       "requires": {
         "debug": "4.3.2",
-        "devtools-protocol": "0.0.937139",
+        "devtools-protocol": "0.0.901419",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.0",
         "node-fetch": "2.6.5",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.2",
     "protractor-console-plugin": "^0.1.1",
-    "puppeteer": "^12.0.1",
+    "puppeteer": "^11.0.0",
     "rimraf": "^3.0.0",
     "rxjs": "^6.5.3",
     "shelljs": "^0.8.3",


### PR DESCRIPTION
Reverts rpbeukes/angular-typesafe-reactive-forms-helper#266

Broken the build, will investigate later.